### PR TITLE
feat: follow conversations

### DIFF
--- a/src/meta_ai_api/__init__.py
+++ b/src/meta_ai_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.7"
+__version__ = "1.2.0"
 from .main import MetaAI  # noqa


### PR DESCRIPTION
For:

#22 
#14 


Can now continue prompting inside the same conversation:

```python
meta = MetaAI()
resp = meta.prompt("what is 2 + 2?", stream=False)
print(resp)

resp = meta.prompt("what was my previous question?", stream=False)
print(resp)
```

```
{'message': '2 + 2 = 4\n', 'sources': [], 'media': []}
{'message': 'Your previous question was "what is 2 + 2?"\n', 'sources': [], 'media': []}
```


To generate a new conversation, you can specify `new_conversation=True` inside prompt method:

```python
meta = MetaAI()
resp = meta.prompt("what is 2 + 2?", stream=False)
print(resp)

resp = meta.prompt("what was my previous question?", stream=False, new_conversation=True)
print(resp)
```

```
{'message': '2 + 2 = 4\n', 'sources': [], 'media': []}
{'message': "This is the beginning of our conversation, so I don't have a previous question to refer to. I'm happy to chat with you, though! What's on your mind today?\n", 'sources': [], 'media': []}
```
